### PR TITLE
Update True_NB_bc95.cpp

### DIFF
--- a/src/True_NB_bc95.cpp
+++ b/src/True_NB_bc95.cpp
@@ -10,7 +10,7 @@ Re-coding to compatible with IoTtweet.com
 
 */
 
-
+#include "itoa.h"		//include for Arduino M0 and M0+ for the physical serial port used
 #include "True_NB_bc95.h"
 
 bool True_NB_bc95::reboot() {


### PR DESCRIPTION
#include "itoa.h" //include for Arduino M0 and M0+ for the physical serial port used. and delete AltSoftSerial Serial2; in main code.